### PR TITLE
[script] [common-arcana] Hold cambrinth if unable to use while worn

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -293,9 +293,16 @@ module DRCA
   def invoke(cambrinth, dedicated_camb_use, invoke_amount)
     return unless cambrinth
 
-    DRC.bput("invoke my #{cambrinth} #{invoke_amount} #{dedicated_camb_use}".strip, get_data('spells').invoke_messages, 'Invoke what?')
+    result = DRC.bput("invoke my #{cambrinth} #{invoke_amount} #{dedicated_camb_use}".strip, get_data('spells').invoke_messages, 'Invoke what?')
     pause
     waitrt?
+    case result
+    when /you find it too clumsy/
+      DRC.message("*** Your arcana skill is too low to invoke your cambrinth while worn")
+      find_cambrinth(cambrinth, false, 999)
+      invoke(cambrinth, dedicated_camb_use, invoke_amount)
+      stow_cambrinth(cambrinth, false, 999)
+    end
   end
 
   def charge?(cambrinth, mana)
@@ -305,6 +312,11 @@ module DRCA
     case result
     when /You are in no condition to do that/
       harness?(mana)
+    when /you find it too clumsy/
+      DRC.message("*** Your arcana skill is too low to charge your cambrinth while worn")
+      find_cambrinth(cambrinth, false, 999)
+      charge?(cambrinth, mana)
+      stow_cambrinth(cambrinth, false, 999)
     else
       result =~ /absorbs? all of the energy/
     end


### PR DESCRIPTION
### Background
* If you have insufficient arcana skill then you cannot charge or invoke cambrinth while it's worn.
* Sorcerous backlash and other effects can lower your effective arcana skill.
* A misconfigured YAML file may cause common-arcana to think you can use the cambrinth while worn when you really can't.

### Changes
* If detect that you cannot charge/invoke cambrinth while worn, hold it then wear it again.

## Tests

### hold cambrinth if unable to use worn

GIVEN:
Arcana ranks insufficient to use a 100 mana cambrinth manacle while worn, and
```yaml
cambrinth: cambrinth manacle
cambrinth_cap: 2 # to cause common-arcana to attempt to use it while worn
stored_cambrinth: false

waggle_sets:
  test:
    Heroic Strength:
      mana: 1
      cambrinth:
        - 1
        - 1
```
THEN:
```
>,buff test

--- Lich: buff active.

[buff]>release mana

You aren't harnessing any mana.
> 
[buff]>prep HES 1

You begin chanting a prayer to invoke the Heroic Strength spell.
> 
[buff]>charge my cambrinth manacle 1

Try though you may, you find it too clumsy to charge the cambrinth manacle while wearing it.
> 
| *** Your arcana skill is too low to charge your cambrinth while worn

[buff]>remove my cambrinth manacle

You remove a heavy cambrinth manacle from your wrist.
> 
You feel fully attuned to the mana streams again.
> 
[buff]>charge my cambrinth manacle 1

You harness a small amount of energy and attempt to channel it into your cambrinth manacle.
You are able to channel all the energy into the manacle.
The cambrinth manacle absorbs all of the energy.
Roundtime: 2 sec.
> 
[buff]>wear my cambrinth manacle

You attach a heavy cambrinth manacle to your wrist.
> 
[buff]>charge my cambrinth manacle 1

Try though you may, you find it too clumsy to charge the cambrinth manacle while wearing it.
> 
| *** Your arcana skill is too low to charge your cambrinth while worn

[buff]>remove my cambrinth manacle

You remove a heavy cambrinth manacle from your wrist.
> 
[buff]>charge my cambrinth manacle 1

You harness a small amount of energy and attempt to channel it into your cambrinth manacle.
You are able to channel all the energy into the manacle.
The cambrinth manacle absorbs all of the energy.
Roundtime: 2 sec.
> 
[buff]>wear my cambrinth manacle

You feel fully attuned to the mana streams again.
> 
You attach a heavy cambrinth manacle to your wrist.
> 
[buff]>invoke my cambrinth manacle

Try though you may, you find it too clumsy to invoke the cambrinth manacle while wearing it.
> 
| *** Your arcana skill is too low to invoke your cambrinth while worn

[buff]>remove my cambrinth manacle

You remove a heavy cambrinth manacle from your wrist.
> 
[buff]>invoke my cambrinth manacle

The cambrinth manacle pulses with Holy energy.  You reach for its center and forge a magical link to it, readying all of its mana for your use.
Roundtime: 1 sec.
> 
[buff]>wear my cambrinth manacle

You attach a heavy cambrinth manacle to your wrist.
> 
You feel fully prepared to cast your spell.
> 
[buff]>cast

You gesture.
Your cambrinth manacle emits a loud *snap* as it discharges all its power to aid your spell.
The spell takes effect, the invisible flame of your soul intertwining with your flesh.  You feel holy strength and vigor course through your body.

> 
--- Lich: buff has exited.
```

### wear cambrinth if able

GIVEN:
Arcana ranks sufficient to use a 32 mana cambrinth armband while worn, and
```yaml
cambrinth: cambrinth armband
cambrinth_cap: 32
stored_cambrinth: false

waggle_sets:
  test:
    Heroic Strength:
      mana: 1
      cambrinth:
        - 1
        - 1
```
THEN:
```
,buff test

--- Lich: buff active.

[buff]>release mana

You aren't harnessing any mana.
> 
[buff]>prep HES 1

You begin chanting a prayer to invoke the Heroic Strength spell.
> 
[buff]>charge my cambrinth armband 1

You harness a small amount of energy and attempt to channel it into your cambrinth armband.
You are able to channel all the energy into the armband.
The cambrinth armband absorbs all of the energy.
Roundtime: 2 sec.
> 
[buff]>charge my cambrinth armband 1

You harness a small amount of energy and attempt to channel it into your cambrinth armband.
You are able to channel all the energy into the armband.
The cambrinth armband absorbs all of the energy.
Roundtime: 2 sec.
> 
[buff]>invoke my cambrinth armband

The cambrinth armband pulses with Holy energy.  You reach for its center and forge a magical link to it, readying all of its mana for your use.
Roundtime: 1 sec.
> 
You feel fully attuned to the mana streams again.
> 
You feel fully prepared to cast your spell.
> 
[buff]>cast

You gesture.
Your cambrinth armband emits a loud *snap* as it discharges all its power to aid your spell.
The spell takes effect, the invisible flame of your soul intertwining with your flesh.  You feel holy strength and vigor course through your body.

> 
--- Lich: buff has exited.
```