### PR TITLE
[script] [common-arcana] try to recover and use cambrinth

### DIFF
--- a/common-arcana.lic
+++ b/common-arcana.lic
@@ -3,7 +3,7 @@
   Documentation: https://elanthipedia.play.net/Lich_script_development#common-arcana
 =end
 
-custom_require.call(%w[common events spellmonitor drinfomon])
+custom_require.call(%w[common common-items events spellmonitor drinfomon])
 
 $MANA_MAP = {
   'weak' => %w[dim glowing bright],
@@ -267,7 +267,7 @@ module DRCA
     if stored_cambrinth
       DRC.bput("get my #{cambrinth}", 'You get', 'You are already holding that')
     elsif DRSkill.getrank('Arcana').to_i < cambrinth_cap * 2 + 100
-      DRC.bput("remove my #{cambrinth}", 'You remove', 'You slide', 'You sling', 'You take', 'You detach', 'You aren\'t wearing that.', 'You grab your','You clutch')
+      DRC.bput("remove my #{cambrinth}", 'You remove', 'You slide', 'You sling', 'You take', 'You detach', 'You aren\'t wearing that.', 'You grab your', 'You clutch', 'You need a free hand')
     end
   end
 
@@ -275,7 +275,7 @@ module DRCA
     if stored_cambrinth
       DRC.bput("stow my #{cambrinth}", 'You put', 'Stow what')
     elsif DRSkill.getrank('Arcana').to_i < cambrinth_cap * 2 + 100
-      DRC.bput("wear my #{cambrinth}", 'You attach', 'You slide', 'You are already wearing', 'You hang', 'You sling', 'You put', 'You place', 'You gently suspend','You slip')
+      DRC.bput("wear my #{cambrinth}", 'You attach', 'You slide', 'You are already wearing', 'You hang', 'You sling', 'You put', 'You place', 'You gently suspend', 'You slip')
     end
   end
 
@@ -299,9 +299,17 @@ module DRCA
     case result
     when /you find it too clumsy/
       DRC.message("*** Your arcana skill is too low to invoke your cambrinth while worn")
-      find_cambrinth(cambrinth, false, 999)
-      invoke(cambrinth, dedicated_camb_use, invoke_amount)
-      stow_cambrinth(cambrinth, false, 999)
+      # If the cambrinth is in your hands and you can't invoke it, nothing else to do.
+      unless DRCI.in_hands?(cambrinth)
+        # Otherwise, try to find the cambrinth and get it to your hands.
+        find_cambrinth(cambrinth, false, 999)
+        # If you were able to get the cambrinth into a hand then retry invoking it.
+        # You might not have been able to if your hands were full.
+        if DRCI.in_hands?(cambrinth)
+          invoke(cambrinth, dedicated_camb_use, invoke_amount)
+          stow_cambrinth(cambrinth, false, 999)
+        end
+      end
     end
   end
 
@@ -314,9 +322,19 @@ module DRCA
       harness?(mana)
     when /you find it too clumsy/
       DRC.message("*** Your arcana skill is too low to charge your cambrinth while worn")
-      find_cambrinth(cambrinth, false, 999)
-      charge?(cambrinth, mana)
-      stow_cambrinth(cambrinth, false, 999)
+      charged = false
+      # If the cambrinth is in your hands and you can't charge it, nothing else to do.
+      unless DRCI.in_hands?(cambrinth)
+        # Otherwise, try to find the cambrinth and get it to your hands.
+        find_cambrinth(cambrinth, false, 999)
+        # If you were able to get the cambrinth into a hand then retry charging it.
+        # You might not have been able to if your hands were full.
+        if DRCI.in_hands?(cambrinth)
+          charged = charge?(cambrinth, mana)
+          stow_cambrinth(cambrinth, false, 999)
+        end
+      end
+      charged
     else
       result =~ /absorbs? all of the energy/
     end


### PR DESCRIPTION
### Background
* My prior change has the potential to introduce infinite recursion if invoking/charging held cambrinth ever gave the message "you find it too clumsy".
* Responding to https://github.com/rpherbig/dr-scripts/pull/4835#issuecomment-805405943

### Changes
* Only try to get the cambrinth item if it's not already in your hands.
* Only try the second invoke/charge attempt if the cambrinth is now in your hands.
* Add match string for `You need a free hand` when try to hold a worn cambrinth.